### PR TITLE
add manual adjustment of fgn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,28 @@ For one-off samples of fBm or fGn there are separate functions available:
     # Get the times associated with the fBm
     t_values = times(n=1024, length=1)
 
+Sometimes you may need to adjust a number (or numbers) at a specified position
+within the fractional Guassian noise realization. E.g., your realization is
+[0.1, -2.1, 3.0, 4.1, ...], but you want to have at position 2, say, 3.5
+instead of 3.0, in the way that all the numbers before remain the same (they
+are already well-correlated), but the next ones, for sure, will have to change
+automatically. You can do it in a following fashion (note, that it will work
+only with Hosking method):
+
+.. code-block:: python
+
+    from fbm import FBM
+
+
+    # This will work only with Hosking method
+    f = FBM(n=1024, hurst=0.75, length=1, method='hosking')
+
+    # Generate a fGn realization
+    fgn_sample = f.fgn()
+
+    # Now we make the manual adjustment in the realization
+    fgn_sample_modified = f.fgn(adjust_rnd=[2, 3.5])
+
 For fastest performance use the Davies and Harte method. Note that the
 Davies and Harte method can fail if the Hurst parameter ``hurst`` is close to
 1 and there are a small amount of increments ``n``. If this occurs, a warning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,10 @@ def hurst_bad(request):
 def hurst_good(request):
     return request.param
 
+@pytest.fixture(params=[[2, 0.5], [3, -0.5]])
+def adjust_rnd_good(request):
+    return request.param
+
 # Bad functions for Hurst in mBm
 def hb1(t):
     return -0.5 + t

--- a/tests/fbm_test.py
+++ b/tests/fbm_test.py
@@ -43,6 +43,14 @@ def test_FBM_fgn(n_good, hurst_good, length_good, fbm_method_good):
     assert isinstance(fgn_sample, np.ndarray)
     assert len(fgn_sample) == n_good
 
+def test_FBM_fgn_adjust_rnd(n_good, hurst_good, length_good,
+                              fbm_method_good, adjust_rnd_good):
+    f = FBM(n_good, hurst_good, length_good, fbm_method_good)
+    fgn_sample = f.fgn()
+    fgn_sample = f.fgn(adjust_rnd_good)
+    assert isinstance(fgn_sample, np.ndarray)
+    assert len(fgn_sample) == n_good
+
 def test_FBM_times(n_good, hurst_good, length_good, fbm_method_good):
     f = FBM(n_good, hurst_good, length_good, fbm_method_good)
     ts = f.times()


### PR DESCRIPTION
When simulating fBm sometimes it is necessary to adjust one position, but maintaining the correct correlations and distribution before it and after it. After one generates f.fgn() now it is possible to adjust the random R at time T with a subsequent command f.fgn(adjust_rnd=[T, R]), which using the same set of gaussian randoms will adjust the fG random at the specified position and re-correlate all the following fG randoms, thus preserving the beginning part precisely as it was. This will work only with Hosking method since it is iterative and does not use FFT.